### PR TITLE
Use published scope when exporting issues and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.17 (XXX, 2020) ##
+
+*   Update the exporter to export published issues only.
+
 ## Dradis Framework 3.16 (February, 2020) ##
 
 *   No changes.

--- a/lib/dradis/plugins/csv/exporter.rb
+++ b/lib/dradis/plugins/csv/exporter.rb
@@ -1,7 +1,7 @@
 module Dradis::Plugins::CSV
   class Exporter < Dradis::Plugins::Export::Base
     def export(args={})
-      issues = content_service.all_issues
+      issues = content_service.all_issues.published
 
       if issues.empty?
         return "The project didn't contain any issues"

--- a/lib/dradis/plugins/csv/gem_version.rb
+++ b/lib/dradis/plugins/csv/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 16
+        MINOR = 17
         TINY  = 0
         PRE   = nil
 


### PR DESCRIPTION
- Limit exported issues to published issues only
- Bump version