### PR TITLE
Use NamingService to assign filename for csv export

### DIFF
--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -12,7 +12,14 @@ class CSVTasks < Thor
     exporter = Dradis::Plugins::CSV::Exporter.new(task_options)
     csv = exporter.export()
 
-    filename = "dradis-report_#{Time.now.to_i}.csv"
+    date = DateTime.now.strftime("%Y-%m-%d")
+    base_filename = "dradis-report_#{date}.csv"
+
+    filename = NamingService.name_file(
+      original_filename: base_filename,
+      pathname: Rails.root
+    )
+
     File.open(filename, 'w') { |f| f.write csv }
 
     logger.info "File written to ./#{ filename }"


### PR DESCRIPTION
### Summary
This PR uses NamingService in dradis main app to find suitable filenames for csv exports.

### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
