### PR TITLE
Release 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 v5.0.0 (March 2026)
-  - No changes
+  - Write file to temporary folder when exported via the command line
 
 v4.19.0 (November 2025)
   - No changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v5.0.0 (March 2026)
+  - No changes
+
 v4.19.0 (November 2025)
   - No changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 v5.0.0 (March 2026)
-  - Write file to temporary folder when exported via the command line
+  - Accept file path argument when exporting via the command line
 
 v4.19.0 (November 2025)
   - No changes

--- a/lib/dradis/plugins/csv_export/gem_version.rb
+++ b/lib/dradis/plugins/csv_export/gem_version.rb
@@ -7,8 +7,8 @@ module Dradis
       end
 
       module VERSION
-        MAJOR = 4
-        MINOR = 19
+        MAJOR = 5
+        MINOR = 0
         TINY = 0
         PRE   = nil
 

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -4,25 +4,31 @@ class CSVTasks < Thor
   namespace "dradis:plugins:csv"
 
   desc "export", "export issues to a CSV file"
+  method_option :output, required: false, type: :string, desc: "the report file to create (if ends in .csv), or directory to create it in"
   def export
     require 'config/environment'
+
+    report_path = options.output || Rails.root.join('tmp')
+    unless report_path.to_s =~ /\.csv\z/
+      date = DateTime.now.strftime("%Y-%m-%d")
+      base_filename = "dradis-report_#{date}.csv"
+
+      report_filename = NamingService.name_file(
+        original_filename: base_filename,
+        pathname: Pathname.new(report_path)
+      )
+
+      report_path = File.join(report_path, report_filename)
+    end
 
     detect_and_set_project_scope
 
     exporter = Dradis::Plugins::CSVExport::Exporter.new(task_options)
     csv = exporter.export()
 
-    date = DateTime.now.strftime("%Y-%m-%d")
-    base_filename = "dradis-report_#{date}.csv"
+    File.open(report_path, 'w') { |f| f.write csv }
 
-    filename = NamingService.name_file(
-      original_filename: base_filename,
-      pathname: Rails.root.join('tmp')
-    )
-
-    File.open(filename, 'w') { |f| f.write csv }
-
-    logger.info "File written to ./#{ filename }"
+    logger.info "Report file created at:\n\t#{report_path}"
   end
 
 end

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -17,7 +17,7 @@ class CSVTasks < Thor
 
     filename = NamingService.name_file(
       original_filename: base_filename,
-      pathname: Rails.root
+      pathname: Rails.root.join('tmp')
     )
 
     File.open(filename, 'w') { |f| f.write csv }


### PR DESCRIPTION
- Accept `output` argument and default to Rails.root.join('tmp') on command line export (since it is owned by the docker user)