### PR TITLE
Only include published evidence when export scope is published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+[v#.#.#] ([month] [YYYY])
+  - Bugs fixed:
+    - Only include Published Evidence in exports when the export scope is set to Published
+
 v5.3.0 (August 2026)
   - No changes
 

--- a/lib/dradis/plugins/csv_export/exporter.rb
+++ b/lib/dradis/plugins/csv_export/exporter.rb
@@ -11,8 +11,9 @@ module Dradis::Plugins::CSVExport
 
         # All fields from all Evidence in the project
         evidence_keys = issues.map do |issue|
-          if issue.evidence.any?
-            issue.evidence.map(&:fields).map(&:keys).flatten.uniq
+          issue_evidence = content_service.evidence_for(issue)
+          if issue_evidence.any?
+            issue_evidence.map(&:fields).map(&:keys).flatten.uniq
           else
             []
           end
@@ -37,9 +38,11 @@ module Dradis::Plugins::CSVExport
               issue.fields.fetch(key, 'n/a')
             end
 
+            issue_evidence = content_service.evidence_for(issue)
+
             # If we've got multiple Evidence, we add one row per Evidence
-            if issue.evidence.any?
-              issue.evidence.each do |evidence|
+            if issue_evidence.any?
+              issue_evidence.each do |evidence|
                 evidence_row = evidence_keys.map do |key|
                   evidence.fields.fetch(key, 'n/a')
                 end

--- a/spec/lib/dradis/plugins/csv_export/exporter_spec.rb
+++ b/spec/lib/dradis/plugins/csv_export/exporter_spec.rb
@@ -1,0 +1,50 @@
+# Run the spec in CE/Pro context with:
+# rspec <relative path to dradis-csv_export>/spec/lib/dradis/plugins/csv_export/exporter_spec.rb
+
+require 'rails_helper'
+
+describe Dradis::Plugins::CSVExport::Exporter do
+  let(:project) { create(:project) }
+  let(:exporter) { described_class.new(project_id: project.id, scope: scope) }
+
+  context 'when the project has no issues' do
+    let(:scope) { :published }
+
+    it "returns a message saying the project didn't contain any issues" do
+      expect(exporter.export).to eq("The project didn't contain any issues")
+    end
+  end
+
+  context 'evidence scope' do
+    let(:node) { create(:node, project: project) }
+    let!(:issue) { create(:issue, node: project.issue_library, state: :published) }
+    let!(:published_evidence) do
+      create(:evidence, issue: issue, node: node, state: :published, content: "#[EvidenceField]#\nPublished evidence\n")
+    end
+    let!(:draft_evidence) do
+      create(:evidence, issue: issue, node: node, state: :draft, content: "#[EvidenceField]#\nDraft evidence\n")
+    end
+
+    context 'published scope' do
+      let(:scope) { :published }
+
+      it 'only includes published evidence' do
+        csv = exporter.export
+
+        expect(csv).to include('Published evidence')
+        expect(csv).not_to include('Draft evidence')
+      end
+    end
+
+    context 'all scope' do
+      let(:scope) { :all }
+
+      it 'includes evidence regardless of state' do
+        csv = exporter.export
+
+        expect(csv).to include('Published evidence')
+        expect(csv).to include('Draft evidence')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

`Exporter#export` called `issue.evidence` directly to build the Evidence rows, bypassing the Published/All export scope that `content_service.all_issues` already respects. A Published-scope export could still leak Draft/Ready-for-review Evidence content into the exported CSV.

- Both call sites now use `content_service.evidence_for(issue)` instead of `issue.evidence`.
- Depends on `dradis-plugins` gem changes (branch `feature/evidence-content-service-scope`) for `evidence_for` — needs a real `dradis-plugins` release + Gemfile bump before this merges. See [dradis-plugins PR #127](https://github.com/dradis/dradis-plugins/pull/127).
- Added `spec/lib/dradis/plugins/csv_export/exporter_spec.rb` — no exporter spec previously existed for this gem.

Part of the same review-comment follow-up as `qa/add-evidence-review-state` (Evidence now has an independent Draft/Ready for review/Published state).

### Testing Steps

From the Dradis Pro app directory, with this gem checked out at a sibling path, temporarily point the Gemfile at this branch/path and run:

```
bin/rspec [dradis-csv_export path]/spec/lib/dradis/plugins/csv_export/exporter_spec.rb
```

Assert all examples pass, confirming a Published-scope export includes only Published evidence content, and an All-scope export includes both Published and Draft evidence content.

### Check List

- [x] Added a CHANGELOG entry
- [x] Added specs
